### PR TITLE
Add netlify compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll', '~> 3.5.2'
 
 require 'json'
 require 'open-uri'


### PR DESCRIPTION
Add Gemfile change which allows Netlify to be used for testing changes by contributors without breaking github pages. Also could cause a fiery death. 